### PR TITLE
docs(todo): update listener and admin UI tech

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ For a full architecture diagram and timing breakdown see **SPECIFICATION.md**.
 * **Google Cloud Speech‑to‑Text**, **Translate**, **Text‑to‑Speech**
 * **Docker 24** / **docker‑compose**
 * **Nginx** static server & reverse proxy
-* SPA frontend written in vanilla TypeScript + Vite
+* Listener interface built with **Streamlit**
+* Admin interface built with **Streamlit**.
 
 ## Repository Layout
 
@@ -37,7 +38,7 @@ For a full architecture diagram and timing breakdown see **SPECIFICATION.md**.
 /edge/hls_packager/     – AAC → LL‑HLS packager
 /scripts/               – utility scripts (deployment, cleanup, etc.)
 /src/                   – shared source code
-/ui/                    – listener web‑app (dist served by Nginx)
+/ui/                    – listener web‑app (Streamlit)
 ```
 
 ## Quick Start (Development)
@@ -96,6 +97,7 @@ See `.env.example` for the full list.
 
 ## Admin Interface
 
+The admin dashboard is implemented using **Streamlit** and served through FastAPI.
 Navigate to **/admin** (HTTP basic auth) to:
 
 * Start/stop the pipeline or switch **Always‑On / Manual / Scheduled** mode.

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -38,10 +38,12 @@ FaithEcho is a real‑time translation service that allows church attendees who 
 * Provide live captions, language selector, text‑size control, volume/mute, latency indicator, and reconnect/report button.
 * Mobile‑first responsive design that works on the latest Chrome, Safari, and Edge browsers.
 * Display a warning if latency exceeds 3 seconds.
+* Implemented using **Streamlit** served by FastAPI.
 
 ### Admin Interface
 
 * Password‑protected admin page (`/admin`) secured by a single shared password.
+* Implemented using **Streamlit** served by FastAPI.
 * Switch operating mode: **Always‑On**, **Manual**, or **Scheduled**.
 * Manual **Start** and **Stop** controls.
 * Live dashboard showing input‑level meter, end‑to‑end latency, and client counts per language.
@@ -102,7 +104,7 @@ FaithEcho is a real‑time translation service that allows church attendees who 
     * **TTS** synthesis requests to Google Cloud Text‑to‑Speech REST (returns base64 AAC).
     * Re‑packs TTS frames into per‑language FIFO pipes.
   * `hls_packager` – ffmpeg packaging the two AAC FIFO inputs into LL‑HLS (1 s segments).
-  * `ui_server` – Nginx serving `/hls` playlists, segments, and the SPA UI.
+  * `ui_server` – Streamlit app serving the listener interface and `/hls` playlists.
   * `admin_api` – Part of `pipeline_worker`; exposes `/admin` with basic auth.
 * **Resources:** 4 vCPU / 8 GB RAM minimum.
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -38,7 +38,7 @@ FaithEcho is a real‑time translation service that allows church attendees who 
 * Provide live captions, language selector, text‑size control, volume/mute, latency indicator, and reconnect/report button.
 * Mobile‑first responsive design that works on the latest Chrome, Safari, and Edge browsers.
 * Display a warning if latency exceeds 3 seconds.
-* Implemented using **Streamlit** served by FastAPI.
+* Implemented using **Streamlit**.
 
 ### Admin Interface
 

--- a/TODO.md
+++ b/TODO.md
@@ -56,7 +56,7 @@
 - [ ] Add credential rotation endpoint `/admin/rotate-gcp`
 - [ ] Write Playwright E2E tests for admin flows
 
-## Milestone 6 — Listener SPA
+## Milestone 6 — Listener Interface
 - [ ] Scaffold Streamlit app under `/ui`
 - [ ] Implement captions overlay Web Component
 - [ ] Add language selector & latency indicator widget

--- a/TODO.md
+++ b/TODO.md
@@ -20,6 +20,11 @@
 - [ ] Provide `scripts/dev‑proxy.sh` with mkcert TLS automation
 - [ ] Update `README.md` with setup / teardown instructions
 
+## Milestone 2.5 — Language service scaffolding
+- [ ] Create base classes for STT, translation and TTS
+- [ ] Stub implementations using Google Cloud clients
+- [ ] Unit tests covering service interfaces
+
 ## Milestone 3 — Core pipeline containers
 ### ingest_ffmpeg
 - [ ] Write entrypoint script with retrying RTMP connection
@@ -47,12 +52,12 @@
 
 ## Milestone 5 — Admin interface
 - [ ] Guard routes with HTTP Basic & bcrypt hash env var
-- [ ] Build admin UI page with live metrics & controls (HTMX or React‑lite)
+- [ ] Build admin UI page with live metrics & controls using Streamlit
 - [ ] Add credential rotation endpoint `/admin/rotate-gcp`
 - [ ] Write Playwright E2E tests for admin flows
 
 ## Milestone 6 — Listener SPA
-- [ ] Initialise Vite + TypeScript project under `/ui`
+- [ ] Scaffold Streamlit app under `/ui`
 - [ ] Implement captions overlay Web Component
 - [ ] Add language selector & latency indicator widget
 - [ ] Add reconnect/report button


### PR DESCRIPTION
## What / Why
- document Streamlit as the framework for both listener and admin interfaces
- tweak edge design and roadmap tasks to reflect Streamlit usage
- keep milestone for STT/translation/TTS scaffolding

## Testing
- `pre-commit run --all-files` *(failed: HTTP 403 fetching ruff-pre-commit)*
- `pytest -q` *(failed: .pytest.ini has no section header)*
- `pnpm test --filter ui...`
- `mypy src/ tests/`
- `ruff format --check`
- `ruff check .`
- `docker compose build` *(failed: docker not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687bdc883078832bb5658efe3b56ae55