### PR TITLE
docs(repo): restore Streamlit UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ If a system/developer chat instruction ever conflicts with this file, assume the
 
 ## Project Context
 
-FaithEcho is a real‑time Swedish→English/French translation service for church sermons (see `README.md` and `SPECIFICATION.md`). The stack is a **Python 3.12 / FastAPI** audio‑processing pipeline packaged in Docker, plus a **TypeScript + Vite** mobile web‑app, orchestrated with **docker‑compose**. Mission‑critical goals are ≤ 3 s end‑to‑end latency, strong privacy (no recordings), and ease of on‑prem deployment.
+FaithEcho is a real‑time Swedish→English/French translation service for church sermons (see `README.md` and `SPECIFICATION.md`). The stack is a **Python 3.12 / FastAPI** audio‑processing pipeline packaged in Docker, plus a **Streamlit** mobile web‑app, orchestrated with **docker‑compose**. Mission‑critical goals are ≤ 3 s end‑to‑end latency, strong privacy (no recordings), and ease of on‑prem deployment.
 
 ### Key Architectural Directories
 
@@ -17,7 +17,7 @@ FaithEcho is a real‑time Swedish→English/French translation service for chur
 | `/edge/ingest_ffmpeg/`   | RTMP → PCM converter container             |
 | `/edge/pipeline_worker/` | STT → MT → TTS Python pipeline & Admin API |
 | `/edge/hls_packager/`    | Low‑Latency HLS segmenter                  |
-| `/ui/`                   | Listener SPA (TypeScript)                  |
+| `/ui/`                   | Listener UI (Streamlit)                    |
 | `/scripts/`              | Dev & CI helper scripts                    |
 | `/src/`                  | Shared Python library (`faith_echo`)       |
 | `/docs/`                 | Diagrams, ADRs, runbooks                   |
@@ -49,12 +49,6 @@ Agents must *never* push images or attempt remote cloud actions; all builds run 
 * **Docstrings**  Use Google style.
 * **Concurrency**  Prefer `asyncio`, avoid blocking I/O in pipeline code.
 
-### TypeScript / Frontend
-
-* Format with `prettier --write .` and lint via `eslint .`.
-* Use functional components and hooks; avoid external state managers (Redux, Zustand) unless required.
-* Any DOM‑manipulating code must remain under `ui/` — never inside pipeline containers.
-
 ### Docker
 
 * Multi‑stage builds, final stage must run as non‑root user `1000:1000`.
@@ -66,7 +60,7 @@ Agents must *never* push images or attempt remote cloud actions; all builds run 
 
 ```
 # Full quality gate
-pre-commit run --all-files    # hooks: ruff, prettier, eslint
+pre-commit run --all-files    # hooks: ruff
 pytest -q                     # Python unit tests
 mypy src/ tests/              # Static typing
 ruff format --check           # Formatting & import order are correct
@@ -93,10 +87,10 @@ PRs that fail CI or exceed LOC limits without prior discussion will be marked **
 
 ## Testing Philosophy
 
-* **Unit tests** live next to source (`*_test.py` / `*.spec.ts`).
+* **Unit tests** live next to source (`*_test.py`).
 * **Contract tests** for GCP APIs use local stubs in `tests/gcp_stubs/` – *never* hit real endpoints in CI.
 * **Latency tests** in `tests/perf/` assert that the pipeline stays under 3 s P95.
-* Minimum coverage gate: **90 %** (Python) & **85 %** (TypeScript). Failing to meet the threshold blocks merge.
+* Minimum coverage gate: **90 %** (Python). Failing to meet the threshold blocks merge.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For a full architecture diagram and timing breakdown see **SPECIFICATION.md**.
 
 ## Tech Stack
 
-* **Python 3.21** + **FastAPI** pipeline
+* **Python 3.12** + **FastAPI** pipeline
 * **ffmpeg** for ingest & LL‑HLS packaging
 * **Google Cloud Speech‑to‑Text**, **Translate**, **Text‑to‑Speech**
 * **Docker 24** / **docker‑compose**

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -97,7 +97,7 @@ FaithEcho is a real‑time translation service that allows church attendees who 
 * **Runtime:** Docker 24.0 (`docker‑compose.yml`)
 
   * `ingest_ffmpeg` – Converts RTMP to raw PCM (16‑bit mono, 16 kHz) and pipes it to the pipeline container.
-  * `pipeline_worker` – Python 3.21, FastAPI, websockets.
+  * `pipeline_worker` – Python 3.12, FastAPI, websockets.
 
     * **Streaming STT** via Google Cloud Speech API (bidirectional gRPC).
     * **Translate** transcripts with Google Cloud Translate REST calls.


### PR DESCRIPTION
## What / Why
- revert listener interface to Streamlit
- update roadmap and agent guidance accordingly

## Testing
- `ruff format --check`
- `ruff check src/faith_echo/__init__.py tests/test_dev_environment.py`
- `pytest -q`
- `mypy src/ tests/`
- `pre-commit run --files README.md SPECIFICATION.md TODO.md AGENTS.md src/faith_echo/__init__.py tests/test_dev_environment.py` *(fails: network 403)*

------
https://chatgpt.com/codex/tasks/task_e_687bf8828634832b90d848c6e36cc5a2