### PR TITLE
feat(services): add readiness and metrics endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,15 @@ For a full architecture diagram and timing breakdown see **SPECIFICATION.md**.
 /ui/                    – listener web‑app (Streamlit)
 ```
 
+## Language Microservices
+
+The STT, Translate and TTS services under `/services` expose three standard
+endpoints:
+
+* `/health` – liveness check
+* `/ready` – readiness check used by docker-compose
+* `/metrics` – Prometheus metrics in text format
+
 ## Quick Start (Development)
 
 > Tested on **Ubuntu 24.04** with Docker 24.x.

--- a/TODO.md
+++ b/TODO.md
@@ -43,7 +43,7 @@
 
   * Accept `TextChunk` stream plus voice parameters
   * Call Google Cloud Text‑to‑Speech; stream back encoded `SpeechChunk` (MP3 64 kb s⁻¹)
-- [ ] Provide health, metrics and readiness endpoints for each service
+- [x] Provide health, metrics and readiness endpoints for each service
 - [ ] Provide individual Dockerfiles and docker‑compose override for running the trio locally
 - [ ] Add typed async Python clients in `faith_echo.sdk`
 - [ ] Unit tests (pytest + pytest‑asyncio) and contract tests (Pact) for service interfaces (≥ 90 % coverage)

--- a/poetry.lock
+++ b/poetry.lock
@@ -440,7 +440,7 @@ google-api-core = {version = ">=1.34.1,<2.0.dev0 || >=2.11.dev0,<3.0.0", extras 
 google-auth = ">=2.14.1,<2.24.0 || >2.24.0,<2.25.0 || >2.25.0,<3.0.0"
 proto-plus = [
     {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
-    {version = ">=1.22.3,<2.0.0", markers = "python_version < \"3.13\""},
+    {version = ">=1.22.3,<2.0.0"},
 ]
 protobuf = ">=3.20.2,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<7.0.0"
 
@@ -463,7 +463,7 @@ google-cloud-core = ">=1.4.4,<3.0.0"
 grpc-google-iam-v1 = ">=0.14.0,<1.0.0"
 proto-plus = [
     {version = ">=1.25.0,<2.0.0", markers = "python_version >= \"3.13\""},
-    {version = ">=1.22.3,<2.0.0"},
+    {version = ">=1.22.3,<2.0.0", markers = "python_version < \"3.13\""},
 ]
 protobuf = ">=3.20.2,<4.21.0 || >4.21.0,<4.21.1 || >4.21.1,<4.21.2 || >4.21.2,<4.21.3 || >4.21.3,<4.21.4 || >4.21.4,<4.21.5 || >4.21.5,<7.0.0"
 
@@ -1124,6 +1124,21 @@ pyyaml = ">=5.1"
 virtualenv = ">=20.10.0"
 
 [[package]]
+name = "prometheus-client"
+version = "0.22.1"
+description = "Python client for the Prometheus monitoring system."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "prometheus_client-0.22.1-py3-none-any.whl", hash = "sha256:cca895342e308174341b2cbf99a56bef291fbc0ef7b9e5412a0f26d653ba7094"},
+    {file = "prometheus_client-0.22.1.tar.gz", hash = "sha256:190f1331e783cf21eb60bca559354e0a4d4378facecf78f5428c39b675d20d28"},
+]
+
+[package.extras]
+twisted = ["twisted"]
+
+[[package]]
 name = "proto-plus"
 version = "1.26.1"
 description = "Beautiful, Pythonic protocol buffers"
@@ -1711,4 +1726,4 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "47a60663dfb2163dc5e7eac8549b17d6235eb47054a17b8e0fa166f36e0357b2"
+content-hash = "e0ff2044dfe2845d788d849d1e6f6068f6d15b3b09dd852a8bff4857efff3e5e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ protobuf = "^6.31.1"
 google-cloud-speech = "^2.26.0"
 google-cloud-translate = "^3.21.1"
 google-cloud-texttospeech = "^2.16.0"
+prometheus-client = ">=0.20,<1.0"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"

--- a/services/stt/main.py
+++ b/services/stt/main.py
@@ -5,7 +5,7 @@ import queue
 import threading
 from typing import AsyncIterator, Iterator
 
-from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 from google.cloud import speech_v1 as speech
 from google.cloud.speech_v1.types import (
     RecognitionConfig,
@@ -14,30 +14,12 @@ from google.cloud.speech_v1.types import (
 )
 from pydantic import BaseModel
 
-from prometheus_client import (
-    CollectorRegistry,
-    CONTENT_TYPE_LATEST,
-    Counter,
-    generate_latest,
-)
+from services.utils import add_monitoring
 
 app = FastAPI(title="FaithEcho STT Service")
 
-# simple Prometheus counter for HTTP requests
-REGISTRY = CollectorRegistry()
-REQUEST_COUNT = Counter(
-    "http_requests_total",
-    "Total HTTP requests",
-    ["method", "endpoint"],
-    registry=REGISTRY,
-)
-
-
-@app.middleware("http")
-async def _count_requests(request: Request, call_next):
-    response = await call_next(request)
-    REQUEST_COUNT.labels(request.method, request.url.path).inc()
-    return response
+# attach Prometheus metrics middleware and endpoint
+add_monitoring(app)
 
 
 class TextChunk(BaseModel):
@@ -117,13 +99,6 @@ async def health() -> dict[str, str]:
 async def ready() -> dict[str, str]:
     """Readiness probe."""
     return {"status": "ready"}
-
-
-@app.get("/metrics")
-async def metrics() -> Response:
-    """Expose Prometheus metrics."""
-    data = generate_latest(REGISTRY)
-    return Response(content=data, media_type=CONTENT_TYPE_LATEST)
 
 
 @app.websocket("/stream")

--- a/services/translate/main.py
+++ b/services/translate/main.py
@@ -4,12 +4,35 @@ import asyncio
 import os
 from typing import AsyncIterator, List
 
-from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi import FastAPI, Request, Response, WebSocket, WebSocketDisconnect
 from google.cloud import translate_v3 as translate
 from google.cloud.translate_v3.types import TranslateTextGlossaryConfig
 from pydantic import BaseModel
 
+from prometheus_client import (
+    CollectorRegistry,
+    CONTENT_TYPE_LATEST,
+    Counter,
+    generate_latest,
+)
+
 app = FastAPI(title="FaithEcho TRANSLATE Service")
+
+REGISTRY = CollectorRegistry()
+REQUEST_COUNT = Counter(
+    "http_requests_total",
+    "Total HTTP requests",
+    ["method", "endpoint"],
+    registry=REGISTRY,
+)
+
+
+@app.middleware("http")
+async def _count_requests(request: Request, call_next):
+    response = await call_next(request)
+    REQUEST_COUNT.labels(request.method, request.url.path).inc()
+    return response
+
 
 # Initialise Google Translate client and configuration once at startup.
 if os.getenv("GOOGLE_APPLICATION_CREDENTIALS"):
@@ -86,6 +109,19 @@ async def translate_stream(
 @app.get("/health")
 async def health() -> dict[str, str]:
     return {"status": "ok"}
+
+
+@app.get("/ready")
+async def ready() -> dict[str, str]:
+    """Readiness probe."""
+    return {"status": "ready"}
+
+
+@app.get("/metrics")
+async def metrics() -> Response:
+    """Expose Prometheus metrics."""
+    data = generate_latest(REGISTRY)
+    return Response(content=data, media_type=CONTENT_TYPE_LATEST)
 
 
 @app.websocket("/stream")

--- a/services/utils.py
+++ b/services/utils.py
@@ -1,0 +1,36 @@
+"""Shared utilities for language services."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI, Request, Response
+from prometheus_client import (
+    CollectorRegistry,
+    CONTENT_TYPE_LATEST,
+    Counter,
+    generate_latest,
+)
+
+
+def add_monitoring(app: FastAPI) -> None:
+    """Attach Prometheus metrics to ``app``."""
+    registry = CollectorRegistry()
+    request_count = Counter(
+        "http_requests_total",
+        "Total HTTP requests",
+        ["method", "endpoint"],
+        registry=registry,
+    )
+
+    @app.middleware("http")
+    async def _count_requests(request: Request, call_next):
+        response = await call_next(request)
+        request_count.labels(request.method, request.url.path).inc()
+        return response
+
+    @app.get("/metrics")
+    async def metrics() -> Response:
+        """Expose Prometheus metrics."""
+        data = generate_latest(registry)
+        return Response(content=data, media_type=CONTENT_TYPE_LATEST)
+
+    app.state.registry = registry

--- a/tests/test_services_health.py
+++ b/tests/test_services_health.py
@@ -14,3 +14,21 @@ def test_service_health(service: str) -> None:
     resp = client.get("/health")
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
+
+
+@pytest.mark.parametrize("service", ["stt", "translate", "tts"])
+def test_service_ready(service: str) -> None:
+    module = importlib.import_module(f"services.{service}.main")
+    client = TestClient(getattr(module, "app"))
+    resp = client.get("/ready")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ready"}
+
+
+@pytest.mark.parametrize("service", ["stt", "translate", "tts"])
+def test_service_metrics(service: str) -> None:
+    module = importlib.import_module(f"services.{service}.main")
+    client = TestClient(getattr(module, "app"))
+    resp = client.get("/metrics")
+    assert resp.status_code == 200
+    assert b"http_requests_total" in resp.content


### PR DESCRIPTION
## What / Why
- expose `/ready` and `/metrics` on STT, Translate and TTS services
- track HTTP requests with Prometheus counters
- document the new endpoints in README
- mark milestone task for health/metrics endpoints complete

## Testing
- `pipx run ruff format --check`
- `pipx run ruff check .`
- `poetry run mypy src/ tests/`
- `poetry run pytest -q`
- `pipx run pre-commit run --all-files` *(failed: HTTP 403 from github.com)*

------
https://chatgpt.com/codex/tasks/task_e_687f80554a98832b8e2d87e6d296bbd6