### PR TITLE
feat(services): add Dockerfiles and compose override

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ endpoints:
 * `/ready` – readiness check used by docker-compose
 * `/metrics` – Prometheus metrics in text format
 
+To run these services stand‑alone for testing, use the override compose file:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.override.yml up stt translate tts
+```
+
 ## Quick Start (Development)
 
 > Tested on **Ubuntu 24.04** with Docker 24.x.

--- a/TODO.md
+++ b/TODO.md
@@ -44,7 +44,7 @@
   * Accept `TextChunk` stream plus voice parameters
   * Call Google Cloud Text‑to‑Speech; stream back encoded `SpeechChunk` (MP3 64 kb s⁻¹)
 - [x] Provide health, metrics and readiness endpoints for each service
-- [ ] Provide individual Dockerfiles and docker‑compose override for running the trio locally
+- [x] Provide individual Dockerfiles and docker‑compose override for running the trio locally
 - [ ] Add typed async Python clients in `faith_echo.sdk`
 - [ ] Unit tests (pytest + pytest‑asyncio) and contract tests (Pact) for service interfaces (≥ 90 % coverage)
 - [ ] CI job `language‑services.yaml` building & testing images

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,13 @@
+services:
+  stt:
+    build: ./services/stt
+    ports:
+      - "8101:8000"
+  translate:
+    build: ./services/translate
+    ports:
+      - "8102:8000"
+  tts:
+    build: ./services/tts
+    ports:
+      - "8103:8000"

--- a/services/stt/Dockerfile
+++ b/services/stt/Dockerfile
@@ -7,7 +7,7 @@ RUN pip install --no-cache-dir poetry && \
     pip install --no-cache-dir -r requirements.txt
 
 FROM base AS test
-CMD ["python", "-m", "pip", "check"]
+RUN ["python", "-m", "pip", "check"]
 
 FROM base AS runtime
 COPY services/stt /app/services/stt

--- a/services/stt/Dockerfile
+++ b/services/stt/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim AS base
+WORKDIR /app
+ENV PYTHONUNBUFFERED=1
+COPY pyproject.toml poetry.lock ./
+RUN pip install --no-cache-dir poetry && \
+    poetry export --without-hashes -f requirements.txt > requirements.txt && \
+    pip install --no-cache-dir -r requirements.txt
+
+FROM base AS test
+CMD ["python", "-m", "pip", "check"]
+
+FROM base AS runtime
+COPY services/stt /app/services/stt
+COPY services/utils.py /app/services/utils.py
+RUN adduser --disabled-password --uid 1000 appuser && chown -R 1000:1000 /app
+USER 1000:1000
+CMD ["uvicorn", "services.stt.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/translate/Dockerfile
+++ b/services/translate/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim AS base
+WORKDIR /app
+ENV PYTHONUNBUFFERED=1
+COPY pyproject.toml poetry.lock ./
+RUN pip install --no-cache-dir poetry && \
+    poetry export --without-hashes -f requirements.txt > requirements.txt && \
+    pip install --no-cache-dir -r requirements.txt
+
+FROM base AS test
+CMD ["python", "-m", "pip", "check"]
+
+FROM base AS runtime
+COPY services/translate /app/services/translate
+COPY services/utils.py /app/services/utils.py
+RUN adduser --disabled-password --uid 1000 appuser && chown -R 1000:1000 /app
+USER 1000:1000
+CMD ["uvicorn", "services.translate.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/translate/Dockerfile
+++ b/services/translate/Dockerfile
@@ -7,7 +7,7 @@ RUN pip install --no-cache-dir poetry && \
     pip install --no-cache-dir -r requirements.txt
 
 FROM base AS test
-CMD ["python", "-m", "pip", "check"]
+RUN ["python", "-m", "pip", "check"]
 
 FROM base AS runtime
 COPY services/translate /app/services/translate

--- a/services/tts/Dockerfile
+++ b/services/tts/Dockerfile
@@ -7,7 +7,7 @@ RUN pip install --no-cache-dir poetry && \
     pip install --no-cache-dir -r requirements.txt
 
 FROM base AS test
-CMD ["python", "-m", "pip", "check"]
+RUN ["python", "-m", "pip", "check"]
 
 FROM base AS runtime
 COPY services/tts /app/services/tts

--- a/services/tts/Dockerfile
+++ b/services/tts/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.12-slim AS base
+WORKDIR /app
+ENV PYTHONUNBUFFERED=1
+COPY pyproject.toml poetry.lock ./
+RUN pip install --no-cache-dir poetry && \
+    poetry export --without-hashes -f requirements.txt > requirements.txt && \
+    pip install --no-cache-dir -r requirements.txt
+
+FROM base AS test
+CMD ["python", "-m", "pip", "check"]
+
+FROM base AS runtime
+COPY services/tts /app/services/tts
+COPY services/utils.py /app/services/utils.py
+RUN adduser --disabled-password --uid 1000 appuser && chown -R 1000:1000 /app
+USER 1000:1000
+CMD ["uvicorn", "services.tts.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## What / Why
- scaffold Dockerfiles for STT, Translate and TTS services
- allow running them locally via `docker-compose.override.yml`
- document how to start the language services
- mark Milestone 3 task as complete

## Testing
- `ruff format .`
- `ruff check --fix .`
- `mypy src/ tests/`
- `pytest -q`
- `ruff format --check`
- `ruff check .`
- `mypy src/ tests/`
- ⚠️ `pre-commit run --all-files` *(failed: HTTP 403 from github.com)*

------
https://chatgpt.com/codex/tasks/task_e_687fad961e70832ba7ff6f0e539e3c25