### PR TITLE
feat(sdk): add async clients

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -45,7 +45,7 @@
   * Call Google Cloud Text‑to‑Speech; stream back encoded `SpeechChunk` (MP3 64 kb s⁻¹)
 - [x] Provide health, metrics and readiness endpoints for each service
 - [x] Provide individual Dockerfiles and docker‑compose override for running the trio locally
-- [ ] Add typed async Python clients in `faith_echo.sdk`
+ - [x] Add typed async Python clients in `faith_echo.sdk`
 - [ ] Unit tests (pytest + pytest‑asyncio) and contract tests (Pact) for service interfaces (≥ 90 % coverage)
 - [ ] CI job `language‑services.yaml` building & testing images
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ google-cloud-speech = "^2.26.0"
 google-cloud-translate = "^3.21.1"
 google-cloud-texttospeech = "^2.16.0"
 prometheus-client = ">=0.20,<1.0"
+websockets = "^12.0"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"
@@ -30,6 +31,7 @@ pre-commit = "^3.7.0"
 grpcio-tools = "^1.73.1"
 shellingham = "^1.5.4"
 httpx = "^0.28.1"
+pytest-asyncio = "^0.23.7"
 
 [build-system]
 requires = ["poetry-core>=1.8.0"]

--- a/src/faith_echo/sdk/__init__.py
+++ b/src/faith_echo/sdk/__init__.py
@@ -1,0 +1,25 @@
+"""Async clients for FaithEcho language microservices."""
+
+from .stt_client import STTClient
+from .translate_client import TranslateClient
+from .tts_client import TTSClient
+from .models import (
+    TextChunk,
+    TranslatedChunk,
+    VoiceParams,
+    SpeechChunk,
+    LangRequest,
+    LangResponse,
+)
+
+__all__ = [
+    "STTClient",
+    "TranslateClient",
+    "TTSClient",
+    "TextChunk",
+    "TranslatedChunk",
+    "VoiceParams",
+    "SpeechChunk",
+    "LangRequest",
+    "LangResponse",
+]

--- a/src/faith_echo/sdk/models.py
+++ b/src/faith_echo/sdk/models.py
@@ -1,0 +1,50 @@
+"""Shared data models for SDK clients."""
+
+from __future__ import annotations
+
+from typing import List
+
+from pydantic import BaseModel
+
+
+class TextChunk(BaseModel):
+    """Transcript chunk."""
+
+    text: str
+    is_final: bool
+    timestamp_ms: int
+
+
+class LangRequest(BaseModel):
+    """Language selection request."""
+
+    source_lang: str
+    target_langs: List[str]
+
+
+class LangResponse(BaseModel):
+    """Confirmation of accepted languages."""
+
+    accepted_langs: List[str]
+
+
+class TranslatedChunk(TextChunk):
+    """Translated text chunk with language code."""
+
+    lang: str
+
+
+class VoiceParams(BaseModel):
+    """Voice parameters for synthesis."""
+
+    lang: str
+    voice: str | None = None
+    speaking_rate: float | None = None
+
+
+class SpeechChunk(BaseModel):
+    """Encoded speech result."""
+
+    audio_b64: str
+    is_final: bool
+    timestamp_ms: int

--- a/src/faith_echo/sdk/stt_client.py
+++ b/src/faith_echo/sdk/stt_client.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import websockets
+
+from .models import TextChunk
+
+
+class STTClient:
+    """Async client for the STT microservice."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    async def stream(self, chunks: AsyncIterator[bytes]) -> AsyncIterator[TextChunk]:
+        """Send audio chunks and yield transcript results."""
+
+        uri = f"{self.base_url}/stream"
+
+        async with websockets.connect(uri) as ws:
+
+            async def sender() -> None:
+                async for chunk in chunks:
+                    await ws.send(chunk)
+                await ws.send("stop")
+
+            send_task = asyncio.create_task(sender())
+            try:
+                async for message in ws:
+                    yield TextChunk.model_validate_json(message)
+            finally:
+                await send_task

--- a/src/faith_echo/sdk/translate_client.py
+++ b/src/faith_echo/sdk/translate_client.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import AsyncIterator, List
+
+import websockets
+
+from .models import LangRequest, TextChunk, TranslatedChunk
+
+
+class TranslateClient:
+    """Async client for the translation microservice."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    async def stream(
+        self,
+        chunks: AsyncIterator[TextChunk],
+        source_lang: str,
+        target_langs: List[str],
+    ) -> AsyncIterator[TranslatedChunk]:
+        """Translate text chunks and yield translated results."""
+
+        uri = f"{self.base_url}/stream"
+        async with websockets.connect(uri) as ws:
+            req = LangRequest(source_lang=source_lang, target_langs=target_langs)
+            await ws.send(req.model_dump_json())
+            await ws.recv()  # LangResponse acknowledgement
+
+            async def sender() -> None:
+                async for chunk in chunks:
+                    await ws.send(chunk.model_dump_json())
+                await ws.send(json.dumps({"stop": True}))
+
+            send_task = asyncio.create_task(sender())
+            try:
+                async for message in ws:
+                    yield TranslatedChunk.model_validate_json(message)
+            finally:
+                await send_task

--- a/src/faith_echo/sdk/tts_client.py
+++ b/src/faith_echo/sdk/tts_client.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import AsyncIterator
+
+import websockets
+
+from .models import SpeechChunk, TextChunk, VoiceParams
+
+
+class TTSClient:
+    """Async client for the TTS microservice."""
+
+    def __init__(self, base_url: str) -> None:
+        self.base_url = base_url.rstrip("/")
+
+    async def stream(
+        self, chunks: AsyncIterator[TextChunk], params: VoiceParams
+    ) -> AsyncIterator[SpeechChunk]:
+        """Synthesize text chunks into speech."""
+
+        uri = f"{self.base_url}/stream"
+        async with websockets.connect(uri) as ws:
+            await ws.send(params.model_dump_json())
+            await ws.recv()  # acknowledgement
+
+            async def sender() -> None:
+                async for chunk in chunks:
+                    await ws.send(chunk.model_dump_json())
+                await ws.send(json.dumps({"stop": True}))
+
+            send_task = asyncio.create_task(sender())
+            try:
+                async for message in ws:
+                    yield SpeechChunk.model_validate_json(message)
+            finally:
+                await send_task

--- a/tests/test_proto_schema.py
+++ b/tests/test_proto_schema.py
@@ -26,6 +26,9 @@ def compile_proto(tmp_path: Path):
     (tmp_path / "faith_echo" / "proto").mkdir(exist_ok=True)
     (tmp_path / "faith_echo" / "proto" / "__init__.py").touch()
     sys.path.insert(0, str(tmp_path))
+    pkg = importlib.import_module("faith_echo")
+    pkg.__path__.insert(0, str(tmp_path / "faith_echo"))
+    importlib.invalidate_caches()
     return importlib.import_module("faith_echo.proto.language_service_pb2")
 
 

--- a/tests/test_sdk_clients.py
+++ b/tests/test_sdk_clients.py
@@ -1,0 +1,147 @@
+import importlib
+import asyncio
+from typing import AsyncIterator, List
+
+import pytest
+from starlette.testclient import TestClient
+from typing import Any
+
+from faith_echo.sdk import (  # type: ignore[import-untyped]
+    STTClient,
+    TranslateClient,
+    TTSClient,
+    TextChunk,
+    VoiceParams,
+)
+
+
+class FakeWS:
+    def __init__(self, session: Any) -> None:  # session is WebSocketTestSession
+        self._session = session
+
+    async def send(self, data) -> None:
+        if isinstance(data, bytes):
+            await asyncio.to_thread(self._session.send_bytes, data)  # type: ignore[attr-defined]
+        else:
+            await asyncio.to_thread(self._session.send_text, data)  # type: ignore[attr-defined]
+
+    def __aiter__(self) -> "FakeWS":
+        return self
+
+    async def __anext__(self) -> str:
+        try:
+            msg = await asyncio.to_thread(self._session.receive_text)  # type: ignore[attr-defined]
+        except Exception as exc:  # connection closed
+            raise StopAsyncIteration from exc
+        return msg
+
+    async def recv(self) -> str:
+        return await self.__anext__()
+
+    async def close(self) -> None:
+        await asyncio.to_thread(self._session.close)  # type: ignore[attr-defined]
+
+
+def make_connect(client: TestClient):
+    def _connect(url: str, *args, **kwargs):
+        path = url.split("testserver")[-1]
+        ctx = client.websocket_connect(path)
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                session = ctx.__enter__()
+                self_inner._session = session
+                return FakeWS(session)
+
+            async def __aexit__(self_inner, exc_type, exc, tb):
+                await asyncio.to_thread(ctx.__exit__, exc_type, exc, tb)
+
+        return _Ctx()
+
+    return _connect
+
+
+@pytest.mark.asyncio
+async def test_stt_client(monkeypatch) -> None:
+    module = importlib.import_module("services.stt.main")
+
+    async def fake_transcribe(_: AsyncIterator[bytes]):
+        yield module.TextChunk(text="a", is_final=False, timestamp_ms=1)
+        yield module.TextChunk(text="b", is_final=True, timestamp_ms=2)
+
+    monkeypatch.setattr(module, "transcribe_stream", fake_transcribe)
+
+    client = TestClient(module.app)
+    monkeypatch.setattr(
+        "faith_echo.sdk.stt_client.websockets.connect", make_connect(client)
+    )
+
+    stt = STTClient("ws://testserver")
+
+    async def audio() -> AsyncIterator[bytes]:
+        yield b"1"
+        yield b"2"
+
+    results = [chunk async for chunk in stt.stream(audio())]
+    assert [r.text for r in results] == ["a", "b"]
+
+
+@pytest.mark.asyncio
+async def test_translate_client(monkeypatch) -> None:
+    module = importlib.import_module("services.translate.main")
+
+    async def fake_translate(
+        chunks: AsyncIterator[TextChunk], source_lang: str, target_langs: List[str]
+    ):
+        async for chunk in chunks:
+            for lang in target_langs:
+                yield module.TranslatedChunk(
+                    text=chunk.text.upper(),
+                    is_final=chunk.is_final,
+                    timestamp_ms=chunk.timestamp_ms,
+                    lang=lang,
+                )
+
+    monkeypatch.setattr(module, "translate_stream", fake_translate)
+
+    client = TestClient(module.app)
+    monkeypatch.setattr(
+        "faith_echo.sdk.translate_client.websockets.connect", make_connect(client)
+    )
+
+    tc = TranslateClient("ws://testserver")
+
+    async def chunks() -> AsyncIterator[TextChunk]:
+        yield TextChunk(text="hej", is_final=False, timestamp_ms=1)
+        yield TextChunk(text="då", is_final=True, timestamp_ms=2)
+
+    results = [r async for r in tc.stream(chunks(), "sv", ["en"])]
+    assert [r.text for r in results] == ["HEJ", "DÅ"]
+
+
+@pytest.mark.asyncio
+async def test_tts_client(monkeypatch) -> None:
+    module = importlib.import_module("services.tts.main")
+
+    async def fake_tts(chunks: AsyncIterator[TextChunk], params: VoiceParams):
+        async for chunk in chunks:
+            yield module.SpeechChunk(
+                audio_b64="deadbeef",
+                is_final=chunk.is_final,
+                timestamp_ms=chunk.timestamp_ms,
+            )
+
+    monkeypatch.setattr(module, "synthesize_stream", fake_tts)
+
+    client = TestClient(module.app)
+    monkeypatch.setattr(
+        "faith_echo.sdk.tts_client.websockets.connect", make_connect(client)
+    )
+
+    tts = TTSClient("ws://testserver")
+
+    async def chunks() -> AsyncIterator[TextChunk]:
+        yield TextChunk(text="hi", is_final=True, timestamp_ms=1)
+
+    results = [r async for r in tts.stream(chunks(), VoiceParams(lang="en"))]
+    assert results[0].audio_b64 == "deadbeef"


### PR DESCRIPTION
## What / Why
- implement typed async clients for language microservices
- add comprehensive unit tests for clients
- update proto tests to handle installed package
- mark TODO item complete

## Testing
- `ruff format --check`
- `ruff check .`
- `pytest -q`
- `mypy src/ tests/`
- `pre-commit run --all-files` *(failed: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687fb456f3cc832b8ce61ba15a2e34e0