### PR TITLE
ci(services): add language services workflow

### DIFF
--- a/.github/workflows/language-services.yaml
+++ b/.github/workflows/language-services.yaml
@@ -1,0 +1,50 @@
+name: Language Services CI
+
+on:
+  push:
+    branches: ["main", "dev"]
+    paths:
+      - "services/**"
+      - "docker-compose.override.yml"
+      - ".github/workflows/language-services.yaml"
+  pull_request:
+    paths:
+      - "services/**"
+      - "docker-compose.override.yml"
+      - ".github/workflows/language-services.yaml"
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build images
+        run: docker compose -f docker-compose.override.yml build stt translate tts
+
+      - name: Start services
+        run: docker compose -f docker-compose.override.yml up -d stt translate tts
+
+      - name: Wait for health endpoints
+        run: |
+          for port in 8101 8102 8103; do
+            for i in {1..10}; do
+              if curl -fs http://localhost:$port/health >/dev/null; then
+                break
+              fi
+              sleep 1
+            done
+          done
+
+      - name: Smoke test
+        run: |
+          curl -f http://localhost:8101/health
+          curl -f http://localhost:8102/health
+          curl -f http://localhost:8103/health
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.override.yml down -v

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ The edge server runs headless in the church LAN:
 ssh church-edge 'docker compose pull && docker compose up -d'
 ```
 
-We recommend provisioning the Google Cloud project via Terraform and wiring the CI/CD workflow in `.github/workflows/` to push new images automatically.
+We recommend provisioning the Google Cloud project via Terraform and wiring the CI/CD workflow in `.github/workflows/` to push new images automatically. A dedicated workflow `language-services.yaml` builds and smoke-tests the STT, Translate and TTS containers on each push.
 
 ## Configuration Reference
 

--- a/SPECIFICATION.md
+++ b/SPECIFICATION.md
@@ -141,7 +141,7 @@ FaithEcho is a real‑time translation service that allows church attendees who 
 
 | Task                            | Tool / Process                                          |
 | ------------------------------- | ------------------------------------------------------- |
-| Build & push images             | GitHub Actions                                          |
+| Build & push images             | GitHub Actions (`language-services.yaml`) |
 | Deploy to edge server           | `docker compose pull && docker compose up -d` via SSH   |
 | Provision Google project & APIs | Terraform or `gcloud` CLI scripts                       |
 | Monitoring                      | Prometheus node exporter + Google Cloud Monitoring      |

--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,7 @@
 - [x] Provide individual Dockerfiles and docker‑compose override for running the trio locally
 - [x] Add typed async Python clients in `faith_echo.sdk`
 - [x] Unit tests (pytest + pytest‑asyncio) and contract tests (Pact) for service interfaces (≥ 90 % coverage)
-- [ ] CI job `language‑services.yaml` building & testing images
+- [x] CI job `language‑services.yaml` building & testing images
 
 ## Milestone 4 — Core pipeline containers
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,13 +1,19 @@
 services:
   stt:
-    build: ./services/stt
+    build:
+      context: .
+      dockerfile: ./services/stt/Dockerfile
     ports:
       - "8101:8000"
   translate:
-    build: ./services/translate
+    build: 
+      context: .
+      dockerfile: ./services/translate/Dockerfile
     ports:
       - "8102:8000"
   tts:
-    build: ./services/tts
+    build:
+      context: .
+      dockerfile: ./services/tts/Dockerfile
     ports:
       - "8103:8000"

--- a/services/stt/Dockerfile
+++ b/services/stt/Dockerfile
@@ -2,7 +2,9 @@ FROM python:3.12-slim AS base
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1
 COPY pyproject.toml poetry.lock ./
-RUN pip install --no-cache-dir poetry && \
+RUN python -m pip install --upgrade pip && \
+    pip install --no-cache-dir poetry && \
+    poetry self add poetry-plugin-export && \
     poetry export --without-hashes -f requirements.txt > requirements.txt && \
     pip install --no-cache-dir -r requirements.txt
 

--- a/services/translate/Dockerfile
+++ b/services/translate/Dockerfile
@@ -2,7 +2,9 @@ FROM python:3.12-slim AS base
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1
 COPY pyproject.toml poetry.lock ./
-RUN pip install --no-cache-dir poetry && \
+RUN python -m pip install --upgrade pip && \
+    pip install --no-cache-dir poetry && \
+    poetry self add poetry-plugin-export && \
     poetry export --without-hashes -f requirements.txt > requirements.txt && \
     pip install --no-cache-dir -r requirements.txt
 

--- a/services/tts/Dockerfile
+++ b/services/tts/Dockerfile
@@ -2,7 +2,9 @@ FROM python:3.12-slim AS base
 WORKDIR /app
 ENV PYTHONUNBUFFERED=1
 COPY pyproject.toml poetry.lock ./
-RUN pip install --no-cache-dir poetry && \
+RUN python -m pip install --upgrade pip && \
+    pip install --no-cache-dir poetry && \
+    poetry self add poetry-plugin-export && \
     poetry export --without-hashes -f requirements.txt > requirements.txt && \
     pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## What / Why
- mark milestone task for language services CI as complete
- add `language-services.yaml` workflow to build and smoke test STT, Translate and TTS images
- reference the new workflow in docs

## Testing
- `poetry run pre-commit run --all-files`
- `poetry run pytest -q`
- `poetry run mypy src/ tests/`
- `poetry run ruff format --check`
- `poetry run ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_687ff9aa4b7c832ba706be8e3423be27