### PR TITLE
feat(pipeline): add jitter buffer for segment alignment

### DIFF
--- a/src/faith_echo/sdk/__init__.py
+++ b/src/faith_echo/sdk/__init__.py
@@ -4,6 +4,7 @@ from .stt_client import STTClient
 from .translate_client import TranslateClient
 from .tts_client import TTSClient
 from .tts_receiver import TTSReceiver
+from .jitter_buffer import SegmentJitterBuffer
 from .models import (
     TextChunk,
     TranslatedChunk,
@@ -18,6 +19,7 @@ __all__ = [
     "TranslateClient",
     "TTSClient",
     "TTSReceiver",
+    "SegmentJitterBuffer",
     "TextChunk",
     "TranslatedChunk",
     "VoiceParams",

--- a/src/faith_echo/sdk/jitter_buffer.py
+++ b/src/faith_echo/sdk/jitter_buffer.py
@@ -25,7 +25,7 @@ class SegmentJitterBuffer:
         """
 
         self._buffers: Dict[str, Dict[int, SpeechChunk]] = {
-            lang: {} for lang in languages
+            lang: {} for lang in set(languages)
         }
 
     def process(self, lang: str, chunk: SpeechChunk) -> List[Dict[str, SpeechChunk]]:

--- a/src/faith_echo/sdk/jitter_buffer.py
+++ b/src/faith_echo/sdk/jitter_buffer.py
@@ -1,0 +1,70 @@
+"""Per-language jitter buffer for aligning reissued segments."""
+
+from __future__ import annotations
+
+from typing import Dict, Iterable, List
+
+from .models import SpeechChunk
+
+
+class SegmentJitterBuffer:
+    """Hold segments per language until all languages finalize a segment.
+
+    Each language maintains its own buffer keyed by ``segment_id``. When a
+    chunk arrives, the latest revision for that language and segment is stored.
+    Once every language has a final revision for the same ``segment_id``, the
+    segment is flushed and returned. Segments are flushed in ascending
+    ``segment_id`` order to preserve playback alignment.
+    """
+
+    def __init__(self, languages: Iterable[str]) -> None:
+        """Initialise buffers for ``languages``.
+
+        Args:
+            languages: Language codes that will supply segments.
+        """
+
+        self._buffers: Dict[str, Dict[int, SpeechChunk]] = {
+            lang: {} for lang in languages
+        }
+
+    def process(self, lang: str, chunk: SpeechChunk) -> List[Dict[str, SpeechChunk]]:
+        """Store ``chunk`` and return any segments ready to flush.
+
+        Args:
+            lang: Language code associated with ``chunk``.
+            chunk: Incoming audio segment.
+
+        Returns:
+            List of flushed segments. Each item maps language codes to their
+            final ``SpeechChunk`` for the flushed ``segment_id``.
+        """
+
+        if lang not in self._buffers:
+            raise KeyError(f"Unknown language: {lang}")
+
+        buf = self._buffers[lang]
+        current = buf.get(chunk.segment_id)
+        if not current or chunk.revision >= current.revision:
+            buf[chunk.segment_id] = chunk
+
+        flushed: List[Dict[str, SpeechChunk]] = []
+        while True:
+            common_ids = set.intersection(
+                *(set(b.keys()) for b in self._buffers.values())
+            )
+            if not common_ids:
+                break
+            seg_id = min(common_ids)
+            if all(
+                self._buffers[lang_key][seg_id].is_final for lang_key in self._buffers
+            ):
+                flushed.append(
+                    {
+                        lang_key: self._buffers[lang_key].pop(seg_id)
+                        for lang_key in self._buffers
+                    }
+                )
+            else:
+                break
+        return flushed

--- a/tests/unit/test_jitter_buffer.py
+++ b/tests/unit/test_jitter_buffer.py
@@ -1,0 +1,44 @@
+import base64
+
+from src.faith_echo.sdk.jitter_buffer import SegmentJitterBuffer  # type: ignore[import-untyped]
+from src.faith_echo.sdk.models import SpeechChunk  # type: ignore[import-untyped]
+
+
+def make_chunk(seg: int, rev: int, final: bool = True) -> SpeechChunk:
+    return SpeechChunk(
+        audio_b64=base64.b64encode(f"{seg}-{rev}".encode()).decode(),
+        is_final=final,
+        timestamp_ms=seg * 100,
+        segment_id=seg,
+        revision=rev,
+    )
+
+
+def test_flushes_when_both_languages_final() -> None:
+    # Arrange
+    buf = SegmentJitterBuffer(["en", "fr"])
+
+    # Act
+    out1 = buf.process("en", make_chunk(1, 0))
+    out2 = buf.process("fr", make_chunk(1, 0))
+
+    # Assert
+    assert out1 == []
+    assert len(out2) == 1
+    flushed = out2[0]
+    assert flushed["en"].segment_id == flushed["fr"].segment_id == 1
+
+
+def test_reissued_segments_replace_and_flush() -> None:
+    # Arrange
+    buf = SegmentJitterBuffer(["en", "fr"])
+
+    # Act
+    buf.process("en", make_chunk(1, 0, final=False))
+    buf.process("fr", make_chunk(1, 0, final=False))
+    buf.process("en", make_chunk(1, 1))
+    out = buf.process("fr", make_chunk(1, 1))
+
+    # Assert
+    flushed = out[0]
+    assert flushed["en"].revision == flushed["fr"].revision == 1


### PR DESCRIPTION
## What / Why
- add `SegmentJitterBuffer` to align reissued audio segments across languages
- expose buffer via SDK for pipeline orchestration

## Testing
- `poetry run pre-commit run --files src/faith_echo/sdk/__init__.py src/faith_echo/sdk/jitter_buffer.py tests/unit/test_jitter_buffer.py`
- `poetry run pytest -q tests/unit tests/integration tests/contracts tests/smoke tests/docker`
- `poetry run mypy src/ tests/`
- `ruff format --check`
- `ruff check .`


------
https://chatgpt.com/codex/tasks/task_e_688f1f1617d0832babd51812dbbffb8e